### PR TITLE
Fix CS chat overflow resend formatting

### DIFF
--- a/bot/bot_server.py
+++ b/bot/bot_server.py
@@ -49,7 +49,14 @@ async def edit_message(message: str, channel: discord.TextChannel, skip_size_che
 
   # Проверка размера только если не указано пропустить
   if not skip_size_check and len(formatted_message) > cs_chat_max_chars:
-    send_message(formatted_message, channel)
+    content = formatted_message
+    prefix = "```ansi\n"
+    suffix = "```"
+
+    if content.startswith(prefix) and content.endswith(suffix):
+      content = content[len(prefix):-len(suffix)]
+
+    await send_message(content, channel)
     return
   
   try:


### PR DESCRIPTION
## Summary
- strip the existing ANSI code block before resending overflow messages
- await the resend call so the coroutine completes before returning

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d7998cbe388327a2fb6014ad74c801