### PR TITLE
Fix single-parameter query tuples in SQL server

### DIFF
--- a/data_server/sql_server.py
+++ b/data_server/sql_server.py
@@ -226,7 +226,7 @@ async def ev_unreg(data):
   user_id = str(interaction.user.id)
 
   query = "DELETE FROM users WHERE discord_id = %s"
-  query_values = (user_id)
+  query_values = (user_id,)
 
   try:
     rows = await mysql.execute_change(query, query_values)
@@ -281,7 +281,7 @@ async def ev_map_delete(data):
 
   # Удаляем из БД
   query = "DELETE FROM maps WHERE map_name = %s"
-  query_values = (data['map_name'])
+  query_values = (data['map_name'],)
 
   try:
     rows = await mysql.execute_change(query, query_values)


### PR DESCRIPTION
## Summary
- ensure the `/unreg` handler passes a one-element tuple to MySQL
- ensure the `/map_delete` handler passes a one-element tuple to MySQL
- reviewed neighboring queries to confirm their parameter tuples are correctly formed

## Testing
- not run (requires database connection)


------
https://chatgpt.com/codex/tasks/task_e_68d79e68320c8327acb943d086d731c3