### PR TITLE
Handle Discord status message errors gracefully

### DIFF
--- a/bot/bot_server.py
+++ b/bot/bot_server.py
@@ -75,9 +75,22 @@ async def edit_status_message(message: str, channel: discord.TextChannel):
     cs_status_message = None
     await send_status_message(message, channel)
     return
+  except discord.HTTPException as err:
+    logger.error(f"Dbot: Ошибка HTTP при получении CS_STATUS в Discord: {err}")
+    cs_status_message = None
+    await send_status_message(message, channel)
+    return
 
   try:
     cs_status_message = await cs_status_message.edit(content=f"```ansi\n{message}```")
+  except discord.Forbidden as err:
+    logger.error(f"Dbot: Нет прав для обновления CS_STATUS в Discord: {err}")
+    cs_status_message = None
+    await send_status_message(message, channel)
+  except discord.HTTPException as err:
+    logger.error(f"Dbot: Ошибка HTTP при обновлении CS_STATUS в Discord: {err}")
+    cs_status_message = None
+    await send_status_message(message, channel)
   except Exception as e:
     logger.error(f"Dbot: Ошибка при обновлении CS_STATUS в Discord: {e}")
 


### PR DESCRIPTION
## Summary
- reset the cached status message when fetching fails with HTTP errors so a new message is created
- recover from forbidden and HTTP failures while editing by recreating the status message

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d7a6d89a5083278f05b0dd4d3c2163